### PR TITLE
Fix code scanning alert no. 25: DOM text reinterpreted as HTML

### DIFF
--- a/Modules/Packages/Upscale.js
+++ b/Modules/Packages/Upscale.js
@@ -1,7 +1,9 @@
+import DOMPurify from 'dompurify';
 //Upscale
 async function upscaleAndDownloadImage(data) {
     try {
-        const imageUrl = imagedir + data;
+        const sanitizedData = DOMPurify.sanitize(data);
+        const imageUrl = imagedir + sanitizedData;
         const imgOriginal = document.createElement('img');
         imgOriginal.src = imageUrl;
         imgOriginal.style.position = 'fixed';

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "axios": "^1.7.9",
-    "electron-context-menu": "^4.0.4"
+    "electron-context-menu": "^4.0.4",
+    "dompurify": "^3.2.3"
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/withinJoel/Elsa/security/code-scanning/25](https://github.com/withinJoel/Elsa/security/code-scanning/25)

To fix the problem, we need to ensure that the `data` parameter is properly sanitized before it is used to form the `imageUrl`. This can be achieved by validating the `data` to ensure it only contains safe characters for a URL path. Additionally, we can use a library like `DOMPurify` to sanitize the input.

1. Import the `DOMPurify` library.
2. Sanitize the `data` parameter before using it to form the `imageUrl`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
