### PR TITLE
Fix code scanning alert no. 19: DOM text reinterpreted as HTML

### DIFF
--- a/Modules/Packages/Detect Face.js
+++ b/Modules/Packages/Detect Face.js
@@ -1,3 +1,5 @@
+import DOMPurify from 'dompurify';
+
 //Detect Faces
 async function detectFaces(data) {
     const existingElement = document.querySelector('[data-role="dynamic-image"]') || document.querySelector('video[data-role="dynamic-video"]') || document.querySelector('[data-role="dynamic-dragged"]');
@@ -23,7 +25,8 @@ async function detectFaces(data) {
     img.style.maxHeight = '500px';
     img.setAttribute('data-role', 'dynamic-image');
 
-    const imgSrc = imagedir + data;
+    const sanitizedData = DOMPurify.sanitize(data);
+    const imgSrc = imagedir + sanitizedData;
     img.src = imgSrc;
 
     // Check if the image source is valid
@@ -75,7 +78,8 @@ async function detectEmotion(data) {
     img.style.maxHeight = '500px';
     img.setAttribute('data-role', 'dynamic-image');
 
-    const imgSrc = imagedir + data;
+    const sanitizedData = DOMPurify.sanitize(data);
+    const imgSrc = imagedir + sanitizedData;
     img.src = imgSrc;
 
     // Check if the image source is valid


### PR DESCRIPTION
Fixes [https://github.com/withinJoel/Elsa/security/code-scanning/19](https://github.com/withinJoel/Elsa/security/code-scanning/19)

To fix the problem, we need to ensure that the `data` variable is properly sanitized before it is used to form the `imgSrc`. This can be achieved by validating the `data` to ensure it is a safe and expected value (e.g., a valid URL or file path). Additionally, we can use a library like `DOMPurify` to sanitize the input.

1. Import the `DOMPurify` library.
2. Use `DOMPurify` to sanitize the `data` variable before concatenating it with `imagedir`.
3. Ensure that the sanitized `data` is used to form the `imgSrc`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
