### PR TITLE
Fix code scanning alert no. 17: DOM text reinterpreted as HTML

### DIFF
--- a/Modules/Packages/Detect Age.js
+++ b/Modules/Packages/Detect Age.js
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify';
 //Detect Age
 async function detectAge(data) {
     const existingElement = document.querySelector('[data-role="dynamic-image"]') || document.querySelector('video[data-role="dynamic-video"]') || document.querySelector('[data-role="dynamic-dragged"]');
@@ -23,7 +24,8 @@ async function detectAge(data) {
     img.style.maxHeight = '500px';
     img.setAttribute('data-role', 'dynamic-image');
 
-    const imgSrc = imagedir + data;
+    const sanitizedData = DOMPurify.sanitize(data);
+    const imgSrc = imagedir + sanitizedData;
     img.src = imgSrc;
 
     // Check if the image source is valid
@@ -57,7 +59,6 @@ async function detectAge(data) {
 
     // Handle image load error
     img.onerror = () => {
-
         echo('Failed to load image.');
     };
 }


### PR DESCRIPTION
Fixes [https://github.com/withinJoel/Elsa/security/code-scanning/17](https://github.com/withinJoel/Elsa/security/code-scanning/17)

To fix the problem, we need to ensure that the `data` variable is properly sanitized before being used to construct the `imgSrc` URL. This can be achieved by using a function that escapes any potentially harmful characters in the `data` variable.

The best way to fix this without changing existing functionality is to use a well-known library like `DOMPurify` to sanitize the `data` variable. This will ensure that any harmful content is removed before it is used in the `imgSrc`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
