### PR TITLE
Fix code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/Modules/Detect File Type.js
+++ b/Modules/Detect File Type.js
@@ -10,6 +10,13 @@ function checkFileExistence(url, callback) {
     img.src = url;
 }
 
+// Function to sanitize data by encoding special characters
+function sanitizeData(data) {
+    return data.replace(/[&<>"'`=\/]/g, function (s) {
+        return "&#" + s.charCodeAt(0) + ";";
+    });
+}
+
 // Detect image type function
 function detectImageType(data) {
     const existingElement = document.querySelector('[data-role="dynamic-image"]');
@@ -17,7 +24,8 @@ function detectImageType(data) {
         existingElement.remove();
     }
 
-    const imageurl = imagedir + data;
+    const sanitizedData = sanitizeData(data);
+    const imageurl = imagedir + sanitizedData;
 
     checkFileExistence(imageurl, function (exists) {
         if (exists) {
@@ -31,15 +39,15 @@ function detectImageType(data) {
             img.setAttribute('data-role', 'dynamic-image');
             document.body.appendChild(img);
 
-            if (data.includes('.png')) {
+            if (sanitizedData.includes('.png')) {
                 echo("The file is in PNG format.");
-            } else if (data.includes('.jpg')) {
+            } else if (sanitizedData.includes('.jpg')) {
                 echo("The file is in JPG format.");
-            } else if (data.includes('.jpeg')) {
+            } else if (sanitizedData.includes('.jpeg')) {
                 echo("The file is in JPEG format.");
-            } else if (data.includes('.webp')) {
+            } else if (sanitizedData.includes('.webp')) {
                 echo("The file is in WEBP format.");
-            } else if (data.includes('.gif')) {
+            } else if (sanitizedData.includes('.gif')) {
                 echo("The file is in GIF format.");
             } else {
                 echo("The file format is unknown.");


### PR DESCRIPTION
Fixes [https://github.com/withinJoel/Elsa/security/code-scanning/2](https://github.com/withinJoel/Elsa/security/code-scanning/2)

To fix the problem, we need to ensure that the `data` used to construct the `imageurl` is properly sanitized to prevent any malicious content from being interpreted as HTML. We can use a function to encode the `data` to ensure that any special characters are escaped, thus preventing XSS attacks.

1. Create a function to sanitize the `data` by encoding special characters.
2. Use this function to sanitize the `data` before constructing the `imageurl`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
